### PR TITLE
Update mobiletemplate.html

### DIFF
--- a/mobile/js/mobiletemplate.html
+++ b/mobile/js/mobiletemplate.html
@@ -23,20 +23,20 @@
 		while (match = search.exec(query))
 		   params[decode(match[1])] = decode(match[2]);
 	    
-		if (params["shortname"] == undefined || params["url"] == undefined || params["title"] == undefined) {
+		if (params["shortname"] === undefined || params["url"] === undefined || params["title"] === undefined) {
 			alert("Required arguments missing");
 		}
 		else {
 			loadComments(params["shortname"], params["url"], params["title"], params["identifier"]);
 		}
-	}
+	};
 	
 	function loadComments(shortname, url, title, identifier) {
 		disqus_url = url;
 		disqus_title = title;
 		disqus_shortname = shortname;
 		
-		if (identifier != undefined)
+		if (identifier !== undefined)
 			disqus_identifier = identifier;
 		else
 			disqus_identifier = "";


### PR DESCRIPTION
=== used instead of == when testing for undefined. Prevents code producing wrong error when the page title is the string undefined.