### PR TITLE
C# SSO: Adding some recommendations for the API key, and disposing of HMACSHA1

### DIFF
--- a/sso/cs/DisqusSSO.cs
+++ b/sso/cs/DisqusSSO.cs
@@ -30,8 +30,9 @@ namespace Disqus.Examples
 
         /// Disqus API secret key can be obtained here: http://disqus.com/api/applications/
         /// This will only work if that key is associated with your SSO remote domain
+        /// It is highly recommended that you DO NOT hard-code your API secret key here, and instead read it from a secure configuration store
         
-        private const string _apiSecret = "DISQUS_SECRET_KEY"; // TODO enter your API secret key
+        private const string _apiSecret = "DISQUS_SECRET_KEY"; // TODO enter your API secret key (for illustrative purposes only)
 
         /// <summary>
         /// Gets the Disqus SSO payload to authenticate users
@@ -84,11 +85,12 @@ namespace Disqus.Examples
 
             // Convert Disqus API key to HMAC-SHA1 signature
             byte[] apiBytes = Encoding.ASCII.GetBytes(_apiSecret);
-            HMACSHA1 hmac = new HMACSHA1(apiBytes);
-            byte[] hashedMessage = hmac.ComputeHash(messageAndTimestampBytes);
+            using (HMACSHA1 hmac = new HMACSHA1(apiBytes)) {
+                byte[] hashedMessage = hmac.ComputeHash(messageAndTimestampBytes);
 
-            // Put it all together into the final payload
-            return Message + " " + ByteToString(hashedMessage) + " " + Timestamp;
+                // Put it all together into the final payload
+                return Message + " " + ByteToString(hashedMessage) + " " + Timestamp;
+            }
         }
 
         private static string ByteToString(byte[] buff)


### PR DESCRIPTION
The current example for C# encourages poor security practices, and leaves a few disposable resources hanging around.  This PR should make it clearer that the const API key is only for illustrative purposes, and shouldn't actually be used in a production environment.

Also, the HMACSHA1 that is being used is never actually disposed, relying instead on finalization to cleanup after itself.  This adds unnecessary pressure to the garbage collector, so to fix this I've wrapped the resource in a using statement block.